### PR TITLE
Fix blurb clipping in book cover PNG download

### DIFF
--- a/src/pages/book-cover-generator.astro
+++ b/src/pages/book-cover-generator.astro
@@ -735,14 +735,21 @@
         g.strokeWeight(1);
         g.line(padding, dividerY, padding + 40 * scale, dividerY);
 
-        // Blurb
+        // Blurb — render line-by-line using pre-wrapped lines so we don't
+        // depend on p5's internal wrap + bounding-box clipping, which clips
+        // text at higher export scales.
         g.noStroke();
         g.fill(TEXT_COLOR);
         g.textFont("Poppins");
         g.textSize(13 * scale);
         g.textLeading(blurbLineHeight);
         g.textAlign(LEFT, TOP);
-        g.text(blurb, padding, blurbStartY, maxTextWidth, blurbHeight + 50);
+
+        let blurbY = blurbStartY;
+        for (const line of blurbLines) {
+          g.text(line, padding, blurbY);
+          blurbY += blurbLineHeight;
+        }
 
         // Branding - pinned to bottom
         g.fill(150);
@@ -760,26 +767,35 @@
         ctx.restore();
       }
 
-      // Helper function to wrap text
+      // Helper function to wrap text — honors explicit newlines in the source
       function wrapText(txt, maxWidth, g = window) {
-        const words = txt.split(" ");
+        const paragraphs = txt.split("\n");
         const lines = [];
-        let currentLine = "";
 
-        for (const word of words) {
-          const testLine = currentLine ? currentLine + " " + word : word;
-          const testWidth = g.textWidth(testLine);
-
-          if (testWidth > maxWidth && currentLine) {
-            lines.push(currentLine);
-            currentLine = word;
-          } else {
-            currentLine = testLine;
+        for (const paragraph of paragraphs) {
+          if (paragraph === "") {
+            lines.push("");
+            continue;
           }
-        }
 
-        if (currentLine) {
-          lines.push(currentLine);
+          const words = paragraph.split(" ");
+          let currentLine = "";
+
+          for (const word of words) {
+            const testLine = currentLine ? currentLine + " " + word : word;
+            const testWidth = g.textWidth(testLine);
+
+            if (testWidth > maxWidth && currentLine) {
+              lines.push(currentLine);
+              currentLine = word;
+            } else {
+              currentLine = testLine;
+            }
+          }
+
+          if (currentLine) {
+            lines.push(currentLine);
+          }
         }
 
         return lines.length > 0 ? lines : [""];


### PR DESCRIPTION
wrapText ignored newline characters so blurbs with paragraph breaks were under-counted. The blurb was rendered with p5's bounding-box text() which honors \n and wraps independently, producing more lines than wrapText computed. The unscaled +50 slack absorbed this at preview scale=1 but not at EXPORT_SCALE=4, clipping the tail of the blurb and the branding in the downloaded PNG.

Split wrapText on newlines first, then word-wrap each paragraph, and render the blurb line-by-line so preview and export produce identical layouts regardless of scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text rendering in the book cover generator with enhanced handling of explicit line breaks and refined text wrapping logic. The generator now more accurately preserves user-formatted text structure when generating book covers, properly supporting multi-line content with correct line break and paragraph formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->