### PR TITLE
Use the new LSC Val Town URL

### DIFF
--- a/src/utils/site.ts
+++ b/src/utils/site.ts
@@ -7,7 +7,7 @@ export const INSTAGRAM_EMBED_URL = `${INSTAGRAM_URL}/embed`;
 export const CONTACT_EMAIL = "mail@livingstoriescollective.org";
 export const PARTNER_INQUIRIES_API_URL =
 	import.meta.env.PUBLIC_PARTNER_INQUIRIES_API_URL ??
-	"https://kamalnrf--71c0e50680fa11f193731607ee4eb77e.web.val.run/api/inquiries";
+	"https://lsc-inquiries.val.run/api/inquiries";
 export const LUMA_CALENDAR_URL = "https://lu.ma/livingstoriesco";
 export const LUMA_CALENDAR_EMBED_URL =
 	"https://lu.ma/embed/calendar/cal-GHDfTF0OIWzcDd9/events?lt=light";

--- a/val/partner-inquiries/README.md
+++ b/val/partner-inquiries/README.md
@@ -3,7 +3,7 @@
 Private Val Town project backing the Partner With Us form and team dashboard.
 
 - Val: `kamalnrf/partner-inquiries`
-- Dashboard: `https://kamalnrf--71c0e50680fa11f193731607ee4eb77e.web.val.run/dashboard`
+- Dashboard: `https://lsc-inquiries.val.run/dashboard`
 - Public endpoint: `POST /api/inquiries`
 
 ## Deployment


### PR DESCRIPTION
## Summary
- point partner inquiry submissions at `https://lsc-inquiries.val.run/api/inquiries`
- update the Val dashboard documentation to `https://lsc-inquiries.val.run/dashboard`

## Verification
- Astro build passes
- invalid API probe reaches validation with HTTP 400
- production-origin CORS preflight is accepted
- dashboard redirects unauthenticated users to Val Town OAuth